### PR TITLE
Reduce dependency on `loop`

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,14 +50,13 @@ Simple REST server can be run like this::
 
 
    loop = asyncio.get_event_loop()
-   server = aiorest.RESTServer(hostname='127.0.0.1',
-                               loop=loop)
+   server = aiorest.RESTServer(hostname='127.0.0.1')
 
    # configure routes
    server.add_url('GET', '/hello', hello)
    # create server
    srv = loop.run_until_complete(loop.create_server(
-       server.make_handler, '127.0.0.1', 8080))
+       server.make_handler(loop=loop), '127.0.0.1', 8080))
 
 
    @asyncio.coroutine

--- a/aiorest/request.py
+++ b/aiorest/request.py
@@ -122,7 +122,7 @@ class Request:
         if self._session_fut is None:
             self._session_fut = fut = asyncio.Future(loop=self._loop)
             if self._session_factory is not None:
-                self._session_factory(self, fut)
+                self._session_factory(self, fut, loop=self._loop)
             else:
                 fut.set_result(None)
         return self._session_fut

--- a/aiorest/server.py
+++ b/aiorest/server.py
@@ -35,13 +35,10 @@ class RESTServer:
     }
 
     def __init__(self, *, hostname, session_factory=None,
-                 enable_cors=False, loop=None,
+                 enable_cors=False,
                  identity_policy=None, auth_policy=None, **kwargs):
         assert session_factory is None or callable(session_factory), \
             "session_factory must be None or callable (coroutine) function"
-        if loop is None:
-            loop = asyncio.get_event_loop()
-        self._loop = loop
         super().__init__()
         self.hostname = hostname
         self.session_factory = session_factory
@@ -55,13 +52,12 @@ class RESTServer:
         self._kwargs = kwargs
         self._urls = []
 
-    def make_handler(self):
-        return RESTRequestHandler(self, hostname=self.hostname,
-                                  session_factory=self.session_factory,
-                                  loop=self._loop,
-                                  identity_policy=self._identity_policy,
-                                  auth_policy=self._auth_policy,
-                                  **self._kwargs)
+    def make_handler(self, loop=None):
+        return lambda: RESTRequestHandler(
+            self, hostname=self.hostname, session_factory=self.session_factory,
+            loop=loop, identity_policy=self._identity_policy,
+            auth_policy=self._auth_policy,
+            **self._kwargs)
 
     @property
     def cors_enabled(self):

--- a/aiorest/server.py
+++ b/aiorest/server.py
@@ -101,6 +101,12 @@ class RESTServer:
         self._urls.append(Entry(compiled, method, handler,
                                 check_cors, cors_options))
 
+    def route(self, path, *, method='GET'):
+        def decorator(f):
+            self.add_url(method, path, f)
+            return f
+        return decorator
+
     @asyncio.coroutine
     def dispatch(self, request):
         path = request.path

--- a/aiorest/session/base.py
+++ b/aiorest/session/base.py
@@ -62,19 +62,16 @@ class _SessionFactory:
     """Session factory.
     """
 
-    def __init__(self, *, session_id_store, backend_store, loop=None):
-        if loop is None:
-            loop = asyncio.get_event_loop()
-        self._loop = loop
+    def __init__(self, *, session_id_store, backend_store):
         assert isinstance(session_id_store, SessionIdStore), session_id_store
         assert isinstance(backend_store, SessionBackendStore), backend_store
         self._sid_store = session_id_store
         self._backend = backend_store
 
-    def __call__(self, request, fut):
+    def __call__(self, request, fut, loop=None):
         """Instantiate Session object.
         """
-        return asyncio.Task(self._load(request, fut), loop=self._loop)
+        return asyncio.Task(self._load(request, fut), loop=loop)
 
     @asyncio.coroutine
     def _load(self, request, fut):
@@ -108,12 +105,11 @@ class _SessionFactory:
         self._sid_store.put_session_id(request, session_id)
 
 
-def create_session_factory(session_id_store, backend_store, *, loop=None):
+def create_session_factory(session_id_store, backend_store):
     """Creates new session factory.
 
     Create new session factory from two storage:
     session_id_store and backend_store.
     """
     return _SessionFactory(session_id_store=session_id_store,
-                           backend_store=backend_store,
-                           loop=loop)
+                           backend_store=backend_store)

--- a/aiorest/session/cookie_session.py
+++ b/aiorest/session/cookie_session.py
@@ -17,8 +17,7 @@ __all__ = [
 def CookieSessionFactory(loads, dumps, secret_key, cookie_name,
                          session_max_age=None,
                          domain=None, max_age=None, path=None,
-                         secure=None, httponly=None,
-                         *, loop=None):
+                         secure=None, httponly=None):
     sid_store = SecureCookie(secret_key, cookie_name,
                              session_max_age=session_max_age,
                              domain=domain, max_age=max_age,
@@ -26,8 +25,7 @@ def CookieSessionFactory(loads, dumps, secret_key, cookie_name,
                              httponly=httponly)
     backend = ClientSideBackend(loads, dumps)
     return create_session_factory(session_id_store=sid_store,
-                                  backend_store=backend,
-                                  loop=loop)
+                                  backend_store=backend)
 
 
 class ClientSideBackend(SessionBackendStore):

--- a/aiorest/session/redis_session.py
+++ b/aiorest/session/redis_session.py
@@ -20,15 +20,14 @@ _dumps = partial(pickle.dumps, protocol=pickle.HIGHEST_PROTOCOL)
 
 def RedisSessionFactory(redis_pool, secret_key, cookie_name, *,
                         loads=_loads, dumps=_dumps, key_prefix='session:',
-                        session_max_age=None, loop=None, **kwargs):
+                        session_max_age=None, **kwargs):
     cookie_store = SecureCookie(secret_key, cookie_name,
                                 session_max_age=session_max_age,
                                 **kwargs)
     backend = RedisBackend(redis_pool, loads=loads, dumps=dumps,
                            session_max_age=session_max_age)
     return create_session_factory(session_id_store=cookie_store,
-                                  backend_store=backend,
-                                  loop=loop)
+                                  backend_store=backend)
 
 
 class RedisBackend(SessionBackendStore):

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -82,12 +82,11 @@ Simple "hello world" REST server would look like this::
         return {'hello': 'world'}
 
     loop = asyncio.get_event_loop()
-    srv = aiorest.RESTServer(hostname='127.0.0.1',
-                                loop=loop)
+    srv = aiorest.RESTServer(hostname='127.0.0.1')
 
     srv.add_url('GET', '/hello', hello)
     server = loop.run_until_complete(loop.create_server(
-        srv.make_handler, '127.0.0.1', 8080))
+        srv.make_handler(loop=loop), '127.0.0.1', 8080))
 
     try:
         loop.run_forever()

--- a/examples/auth.py
+++ b/examples/auth.py
@@ -64,14 +64,14 @@ def main():
     auth_policy = DictionaryAuthorizationPolicy({'chris': ('read',)})
 
     server = aiorest.RESTServer(
-        hostname='127.0.0.1', loop=loop,
+        hostname='127.0.0.1',
         identity_policy=identity_policy,
         auth_policy=auth_policy
     )
     server.add_url('GET', '/auth/{permission}', handler)
 
     srv = loop.run_until_complete(loop.create_server(
-        server.make_handler, '127.0.0.1', 8080))
+        server.make_handler(loop=loop), '127.0.0.1', 8080))
 
     @asyncio.coroutine
     def query():

--- a/examples/class_server.py
+++ b/examples/class_server.py
@@ -21,10 +21,10 @@ class App(aiorest.RESTServer):
 def main():
     loop = asyncio.get_event_loop()
 
-    server = App(hostname='127.0.0.1', loop=loop)
+    server = App(hostname='127.0.0.1')
 
     srv = loop.run_until_complete(loop.create_server(
-        server.make_handler, '127.0.0.1', 8080))
+        server.make_handler(loop=loop), '127.0.0.1', 8080))
 
     @asyncio.coroutine
     def query():

--- a/examples/cookie_session.py
+++ b/examples/cookie_session.py
@@ -30,17 +30,15 @@ def main():
     session_factory = CookieSessionFactory(secret_key=b'secret',
                                            cookie_name='test_cookie',
                                            dumps=json.dumps,
-                                           loads=json.loads,
-                                           loop=loop)
+                                           loads=json.loads)
 
     server = aiorest.RESTServer(hostname='127.0.0.1', keep_alive=75,
-                                session_factory=session_factory,
-                                loop=loop)
+                                session_factory=session_factory)
 
     server.add_url('GET', '/count', handler.counter)
 
     srv = loop.run_until_complete(loop.create_server(
-        server.make_handler, '127.0.0.1', 8080))
+        server.make_handler(loop=loop), '127.0.0.1', 8080))
 
     @asyncio.coroutine
     def query():

--- a/examples/hello_world.py
+++ b/examples/hello_world.py
@@ -15,12 +15,12 @@ def say_hello(request):
 def main():
     loop = asyncio.get_event_loop()
 
-    server = aiorest.RESTServer(hostname='127.0.0.1', loop=loop)
+    server = aiorest.RESTServer(hostname='127.0.0.1')
     server.add_url('GET', '/hello-world', handler)
     server.add_url('GET', '/hello/{name}', say_hello)
 
     srv = loop.run_until_complete(loop.create_server(
-        server.make_handler, '127.0.0.1', 8080))
+        server.make_handler(loop=loop), '127.0.0.1', 8080))
 
     @asyncio.coroutine
     def query():

--- a/examples/redis_session.py
+++ b/examples/redis_session.py
@@ -35,17 +35,15 @@ def main():
 
     session_factory = RedisSessionFactory(redis,
                                           secret_key=b'secret',
-                                          cookie_name='test_cookie',
-                                          loop=loop)
+                                          cookie_name='test_cookie')
 
     server = aiorest.RESTServer(hostname='127.0.0.1', keep_alive=75,
-                                session_factory=session_factory,
-                                loop=loop)
+                                session_factory=session_factory)
 
     server.add_url('GET', '/count', handler.counter)
 
     srv = loop.run_until_complete(loop.create_server(
-        server.make_handler, '127.0.0.1', 8080))
+        server.make_handler(loop=loop), '127.0.0.1', 8080))
 
     @asyncio.coroutine
     def query():

--- a/tests/cookie_session_test.py
+++ b/tests/cookie_session_test.py
@@ -63,12 +63,10 @@ class CookieSessionTests(unittest.TestCase):
         session_factory = CookieSessionFactory(secret_key=b'secret',
                                                cookie_name='test_cookie',
                                                dumps=json.dumps,
-                                               loads=json.loads,
-                                               loop=self.loop)
+                                               loads=json.loads)
         self.server = RESTServer(debug=True, keep_alive=75,
                                  hostname='localhost',
-                                 session_factory=session_factory,
-                                 loop=self.loop)
+                                 session_factory=session_factory)
         rest = REST(self)
 
         self.server.add_url('GET', '/init', rest.init_session)
@@ -82,7 +80,7 @@ class CookieSessionTests(unittest.TestCase):
     @contextlib.contextmanager
     def run_server(self):
         srv = self.loop.run_until_complete(self.loop.create_server(
-            self.server.make_handler,
+            self.server.make_handler(loop=self.loop),
             '127.0.0.1', 0))
         sock = next(iter(srv.sockets))
         host, port = sock.getsockname()

--- a/tests/cors_test.py
+++ b/tests/cors_test.py
@@ -24,8 +24,7 @@ class CorsTests(unittest.TestCase):
         self.loop = asyncio.new_event_loop()
         asyncio.set_event_loop(None)
         self.server = RESTServer(debug=True, hostname='localhost',
-                                 enable_cors=True,
-                                 loop=self.loop)
+                                 enable_cors=True)
         add_url = self.server.add_url
 
         rest = REST(self)
@@ -41,7 +40,7 @@ class CorsTests(unittest.TestCase):
         self.assertTrue(self.server.cors_enabled)
 
         srv = self.loop.run_until_complete(self.loop.create_server(
-            self.server.make_handler,
+            self.server.make_handler(loop=self.loop),
             '127.0.0.1', 0))
         self.assertEqual(len(srv.sockets), 1)
         sock = next(iter(srv.sockets))

--- a/tests/redis_session_test.py
+++ b/tests/redis_session_test.py
@@ -26,8 +26,7 @@ class RedisSessionTests(unittest.TestCase):
         self.loop.close()
 
     def test_load_empty(self):
-        factory = RedisSessionFactory(self.redis_pool, 'secret', 'test',
-                                      loop=self.loop)
+        factory = RedisSessionFactory(self.redis_pool, 'secret', 'test')
 
         sid_store = factory._sid_store
         req = mock.Mock()
@@ -36,7 +35,7 @@ class RedisSessionTests(unittest.TestCase):
         @asyncio.coroutine
         def run():
             fut = asyncio.Future(loop=self.loop)
-            factory(req, fut)
+            factory(req, fut, loop=self.loop)
             sess = yield from fut
             self.assertEqual(sess, {})
             self.assertTrue(sess.new)
@@ -44,8 +43,7 @@ class RedisSessionTests(unittest.TestCase):
         self.loop.run_until_complete(run())
 
     def test_load_existent(self):
-        factory = RedisSessionFactory(self.redis_pool, 'secret', 'test',
-                                      loop=self.loop)
+        factory = RedisSessionFactory(self.redis_pool, 'secret', 'test')
         sid_store = factory._sid_store
         req = mock.Mock()
         req.cookies.get.return_value = sid_store._encode_cookie('123')
@@ -59,7 +57,7 @@ class RedisSessionTests(unittest.TestCase):
                 ok = yield from redis.set(key, data)
                 self.assertTrue(ok)
             fut = asyncio.Future(loop=self.loop)
-            factory(req, fut)
+            factory(req, fut, loop=self.loop)
             sess = yield from fut
             self.assertFalse(sess.new)
             self.assertEqual(sess, {'foo': 'bar'})

--- a/tests/router_test.py
+++ b/tests/router_test.py
@@ -12,7 +12,7 @@ class RouterTests(unittest.TestCase):
     def setUp(self):
         self.loop = asyncio.new_event_loop()
         asyncio.set_event_loop(None)
-        self.server = RESTServer(hostname='example.com', loop=self.loop)
+        self.server = RESTServer(hostname='example.com')
 
     def tearDown(self):
         self.loop.close()

--- a/tests/security_test.py
+++ b/tests/security_test.py
@@ -55,7 +55,7 @@ class ServerTests(unittest.TestCase):
         asyncio.set_event_loop(None)
         auth_policy = DictionaryAuthorizationPolicy({'chris': ('read',)})
         self.server = RESTServer(debug=True, keep_alive=75,
-                                 hostname='127.0.0.1', loop=self.loop,
+                                 hostname='127.0.0.1',
                                  identity_policy=CookieIdentityPolicy(),
                                  auth_policy=auth_policy)
         self.port = None
@@ -66,9 +66,9 @@ class ServerTests(unittest.TestCase):
         self.loop.close()
 
     def test_identity_missing(self):
-        srv = self.loop.run_until_complete(self.loop.create_server(
-                                           self.server.make_handler,
-                                           '127.0.0.1', 0))
+        srv = self.loop.run_until_complete(
+            self.loop.create_server(self.server.make_handler(loop=self.loop),
+                                    '127.0.0.1', 0))
         self.port = port = server_port(srv)
         url = 'http://127.0.0.1:{}/auth'.format(port)
 
@@ -87,9 +87,9 @@ class ServerTests(unittest.TestCase):
         self.loop.run_until_complete(srv.wait_closed())
 
     def test_user_missing(self):
-        srv = self.loop.run_until_complete(self.loop.create_server(
-                                           self.server.make_handler,
-                                           '127.0.0.1', 0))
+        srv = self.loop.run_until_complete(
+            self.loop.create_server(self.server.make_handler(loop=self.loop),
+                                    '127.0.0.1', 0))
         self.port = port = server_port(srv)
         url = 'http://127.0.0.1:{}/auth'.format(port)
 
@@ -108,9 +108,9 @@ class ServerTests(unittest.TestCase):
         self.loop.run_until_complete(srv.wait_closed())
 
     def test_permission_missing(self):
-        srv = self.loop.run_until_complete(self.loop.create_server(
-                                           self.server.make_handler,
-                                           '127.0.0.1', 0))
+        srv = self.loop.run_until_complete(
+            self.loop.create_server(self.server.make_handler(loop=self.loop),
+                                    '127.0.0.1', 0))
         self.port = port = server_port(srv)
         url = 'http://127.0.0.1:{}/auth'.format(port)
 
@@ -129,9 +129,9 @@ class ServerTests(unittest.TestCase):
         self.loop.run_until_complete(srv.wait_closed())
 
     def test_permission_present(self):
-        srv = self.loop.run_until_complete(self.loop.create_server(
-                                           self.server.make_handler,
-                                           '127.0.0.1', 0))
+        srv = self.loop.run_until_complete(
+            self.loop.create_server(self.server.make_handler(loop=self.loop),
+                                    '127.0.0.1', 0))
         self.port = port = server_port(srv)
         url = 'http://127.0.0.1:{}/auth'.format(port)
 

--- a/tests/server_test.py
+++ b/tests/server_test.py
@@ -82,7 +82,7 @@ class ServerTests(unittest.TestCase):
         self.loop = asyncio.new_event_loop()
         asyncio.set_event_loop(None)
         self.server = RESTServer(debug=True, keep_alive=75,
-                                 hostname='127.0.0.1', loop=self.loop)
+                                 hostname='127.0.0.1')
         self.port = None
         rest = REST(self)
         self.server.add_url('POST', '/post/{id}', rest.func_POST)
@@ -98,7 +98,7 @@ class ServerTests(unittest.TestCase):
 
     def test_simple_POST(self):
         srv = self.loop.run_until_complete(self.loop.create_server(
-            self.server.make_handler,
+            self.server.make_handler(loop=self.loop),
             '127.0.0.1', 0))
         self.port = port = server_port(srv)
         url = 'http://127.0.0.1:{}/post/123'.format(port)
@@ -119,9 +119,9 @@ class ServerTests(unittest.TestCase):
         self.loop.run_until_complete(srv.wait_closed())
 
     def test_simple_GET(self):
-        srv = self.loop.run_until_complete(self.loop.create_server(
-                                           self.server.make_handler,
-                                           '127.0.0.1', 0))
+        srv = self.loop.run_until_complete(
+            self.loop.create_server(self.server.make_handler(loop=self.loop),
+                                    '127.0.0.1', 0))
         self.port = port = server_port(srv)
         url = 'http://127.0.0.1:{}/post/123'.format(port)
 
@@ -138,7 +138,7 @@ class ServerTests(unittest.TestCase):
 
     def test_GET_with_query_string(self):
         srv = self.loop.run_until_complete(self.loop.create_server(
-            self.server.make_handler,
+            self.server.make_handler(loop=self.loop),
             '127.0.0.1', 0))
         self.port = port = server_port(srv)
         url = 'http://127.0.0.1:{}/post/123/2?a=1&b=2'.format(port)
@@ -159,7 +159,7 @@ class ServerTests(unittest.TestCase):
 
     def test_set_cookie(self):
         srv = self.loop.run_until_complete(self.loop.create_server(
-            self.server.make_handler,
+            self.server.make_handler(loop=self.loop),
             '127.0.0.1', 0))
         self.port = port = server_port(srv)
         url = 'http://127.0.0.1:{}/cookie/123'.format(port)
@@ -179,7 +179,7 @@ class ServerTests(unittest.TestCase):
 
     def test_get_cookie(self):
         srv = self.loop.run_until_complete(self.loop.create_server(
-            self.server.make_handler,
+            self.server.make_handler(loop=self.loop),
             '127.0.0.1', 0))
         self.port = port = server_port(srv)
         url = 'http://127.0.0.1:{}/get_cookie/'.format(port)
@@ -203,7 +203,7 @@ class ServerTests(unittest.TestCase):
 
     def test_accept_encoding__deflate(self):
         srv = self.loop.run_until_complete(self.loop.create_server(
-            self.server.make_handler,
+            self.server.make_handler(loop=self.loop),
             '127.0.0.1', 0))
         self.port = port = server_port(srv)
         url = 'http://127.0.0.1:{}/post/123'.format(port)
@@ -224,7 +224,7 @@ class ServerTests(unittest.TestCase):
 
     def test_accept_encoding__gzip(self):
         srv = self.loop.run_until_complete(self.loop.create_server(
-            self.server.make_handler,
+            self.server.make_handler(loop=self.loop),
             '127.0.0.1', 0))
         self.port = port = server_port(srv)
         url = 'http://127.0.0.1:{}/post/123'.format(port)
@@ -245,7 +245,7 @@ class ServerTests(unittest.TestCase):
 
     def test_POST_without_body(self):
         srv = self.loop.run_until_complete(self.loop.create_server(
-            self.server.make_handler,
+            self.server.make_handler(loop=self.loop),
             '127.0.0.1', 0))
         self.port = port = server_port(srv)
         url = 'http://127.0.0.1:{}/post/123'.format(port)
@@ -270,7 +270,7 @@ class ServerTests(unittest.TestCase):
 
     def test_POST_malformed_json(self):
         srv = self.loop.run_until_complete(self.loop.create_server(
-            self.server.make_handler,
+            self.server.make_handler(loop=self.loop),
             '127.0.0.1', 0))
         self.port = port = server_port(srv)
         url = 'http://127.0.0.1:{}/post/123'.format(port)
@@ -295,7 +295,7 @@ class ServerTests(unittest.TestCase):
 
     def test_POST_nonutf8_json(self):
         srv = self.loop.run_until_complete(self.loop.create_server(
-            self.server.make_handler,
+            self.server.make_handler(loop=self.loop),
             '127.0.0.1', 0))
         self.port = port = server_port(srv)
         url = 'http://127.0.0.1:{}/post/123'.format(port)
@@ -320,7 +320,7 @@ class ServerTests(unittest.TestCase):
 
     def test_status_code(self):
         srv = self.loop.run_until_complete(self.loop.create_server(
-            self.server.make_handler,
+            self.server.make_handler(loop=self.loop),
             '127.0.0.1', 0))
         self.port = port = server_port(srv)
         url = 'http://127.0.0.1:{}/create'.format(port)
@@ -341,7 +341,7 @@ class ServerTests(unittest.TestCase):
 
     def test_no_session(self):
         srv = self.loop.run_until_complete(self.loop.create_server(
-            self.server.make_handler,
+            self.server.make_handler(loop=self.loop),
             '127.0.0.1', 0))
         self.port = port = server_port(srv)
         url = 'http://127.0.0.1:{}/check/no/session'.format(port)

--- a/tests/session_factory_test.py
+++ b/tests/session_factory_test.py
@@ -25,17 +25,15 @@ class SessionFactoryTests(unittest.TestCase):
 
         factory = create_session_factory(self.dummy_sid, self.dummy_storage)
         self.assertIsInstance(factory, _SessionFactory)
-        self.assertIs(factory._loop, self.loop)
 
     def test_asserts(self):
         with self.assertRaises(AssertionError):
-            create_session_factory(None, self.dummy_storage, loop=self.loop)
+            create_session_factory(None, self.dummy_storage)
         with self.assertRaises(AssertionError):
-            create_session_factory(self.dummy_sid, None, loop=self.loop)
+            create_session_factory(self.dummy_sid, None)
 
     def test_create_new_session(self):
-        factory = create_session_factory(self.dummy_sid, self.dummy_storage,
-                                         loop=self.loop)
+        factory = create_session_factory(self.dummy_sid, self.dummy_storage)
 
         @asyncio.coroutine
         def load(session_id):
@@ -48,7 +46,7 @@ class SessionFactoryTests(unittest.TestCase):
             waiter = asyncio.Future(loop=self.loop)
             req = mock.Mock()
 
-            factory(req, waiter)
+            factory(req, waiter, loop=self.loop)
 
             sess = yield from asyncio.wait_for(waiter, timeout=1,
                                                loop=self.loop)
@@ -64,8 +62,7 @@ class SessionFactoryTests(unittest.TestCase):
         self.dummy_storage.save_session_data.assert_call_count(0)
 
     def test_load_existing_session(self):
-        factory = create_session_factory(self.dummy_sid, self.dummy_storage,
-                                         loop=self.loop)
+        factory = create_session_factory(self.dummy_sid, self.dummy_storage)
         request = mock.Mock()
 
         self.dummy_sid.get_session_id.return_value = 123
@@ -80,7 +77,7 @@ class SessionFactoryTests(unittest.TestCase):
         @asyncio.coroutine
         def go():
             waiter = asyncio.Future(loop=self.loop)
-            factory(request, waiter)
+            factory(request, waiter, loop=self.loop)
             sess = yield from asyncio.wait_for(waiter, timeout=1,
                                                loop=self.loop)
 
@@ -93,8 +90,7 @@ class SessionFactoryTests(unittest.TestCase):
         self.dummy_storage.save_session_data.assert_call_count(0)
 
     def test_load_and_save(self):
-        factory = create_session_factory(self.dummy_sid, self.dummy_storage,
-                                         loop=self.loop)
+        factory = create_session_factory(self.dummy_sid, self.dummy_storage)
 
         @asyncio.coroutine
         def load(session_id):
@@ -112,7 +108,7 @@ class SessionFactoryTests(unittest.TestCase):
             waiter = asyncio.Future(loop=self.loop)
             req = mock.Mock()
 
-            factory(req, waiter)
+            factory(req, waiter, loop=self.loop)
 
             sess = yield from asyncio.wait_for(waiter, timeout=1,
                                                loop=self.loop)


### PR DESCRIPTION
As shown in aiohttp, `Server` can be coupled with `loop` in a looser way, so that it is easier to write code with loop-replace-ability in mind, like creating `Server` instance at module level without specifying a loop instance and only pass in one when needed (`make_handler`).

Also added a Flask-style handy `route` decorator
